### PR TITLE
feat: add workflow step persistence

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -1,0 +1,34 @@
+const fs = require('fs')
+
+class FlatFilePersistence {
+  constructor(fileName) {
+    this.fileName = fileName
+  }
+
+  load() {
+    const label = `Loading data from ${this.fileName}`
+    console.time(label)
+    try {
+      let ret = fs.readFileSync(this.fileName, 'utf8')
+      ret = JSON.parse(ret)
+      console.timeEnd(label)
+      return ret
+    } catch (err) {
+      console.timeEnd(label)
+      throw new Error(`Unable to load persistence from file "${this.fileName}"`)
+    }
+  }
+
+  save(data) {
+    const label = `Saving data to ${this.fileName}`
+    console.time(label)
+    try {
+      fs.writeFileSync(this.fileName, JSON.stringify(data), 'utf8')
+      console.timeEnd(label)
+    } catch (err) {
+      throw new Error(`Unable to save persistence to file "${this.fileName}"`)
+    }
+  }
+}
+
+module.exports = FlatFilePersistence

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -14,16 +14,17 @@ const pick = require('lodash.pick')
 class Workflow extends BatchJob {
   static type = 'workflow'
 
-  constructor(data) {
+  constructor(data, workflowPersistence = undefined) {
     super({
       type: Workflow.type,
-      state: {
+      state: Workflow.getPersistedState(workflowPersistence) || {
         jobIndex: 0
       },
       ...data
     })
 
     const { pipeline } = this.params
+    this.workflowPersistence = workflowPersistence
 
     if (!pipeline) {
       throw new Error(
@@ -47,7 +48,7 @@ class Workflow extends BatchJob {
 
   async _run() {
     const { pipeline, ...sharedParams } = this.params
-    let { jobIndex = 0 } = this.state
+    let jobIndex = this.state.jobIndex
     let job
 
     while (jobIndex < pipeline.length) {
@@ -60,6 +61,7 @@ class Workflow extends BatchJob {
       }
 
       if (!this.state.pipeline) {
+        console.log('Workflow starting from scratch')
         this.state.pipeline = []
       }
 
@@ -141,6 +143,13 @@ class Workflow extends BatchJob {
       })
 
       this.state.jobIndex = ++jobIndex
+
+      if (jobConfig.saveOnSuccess && this.workflowPersistence) {
+        this.workflowPersistence.save({
+          state: this.state,
+          pipeline: this.state.pipeline
+        })
+      }
     }
 
     if (job) {
@@ -148,6 +157,21 @@ class Workflow extends BatchJob {
         results: job.results
       }
     }
+  }
+
+  static getPersistedState(workflowPersistence) {
+    const loadPersistedState = () => {
+      try {
+        const data = workflowPersistence.load()
+        return { state: data.state, pipeline: data.pipeline }
+      } catch (e) {
+        return undefined
+      }
+    }
+
+    if (!workflowPersistence) return undefined
+    const persisted = loadPersistedState()
+    return persisted ? persisted.state : undefined
   }
 }
 


### PR DESCRIPTION
Add the ability to persist entire workflow steps to disk.
The state of the workflow pipeline is saved to disk, so the next step can be processed directly when reloading the app in case of cold start.

This is useful e.g to avoid retrieving the followers list every time, or lookup their profile data.

Currently, the BatchJobTwitterSendDirectMessages is marked as not persistable (since it has side effects). It is also a good candidate for a future fine-grained persistence (i.e, not all or none).

